### PR TITLE
chore: env var change

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17367,7 +17367,7 @@ const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 const getValidatedEnvVars = (key, re) => {
-  const value = (external_process_default()).env[key.toUpperCase()] || ""
+  const value = (external_process_default()).env[key] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }
@@ -17552,10 +17552,10 @@ async function run() {
     // values that are not, strictly speaking, valid, but should be good
     // enough for detecting obvious errors, which is all we want here.
     const options = {
-      "tmate-server-host": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
-      "tmate-server-port": /^\d{1,5}$/,
-      "tmate-server-rsa-fingerprint": /./,
-      "tmate-server-ed25519-fingerprint": /./,
+      "TMATE_SERVER_HOST": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
+      "TMATE_SERVER_PORT": /^\d{1,5}$/,
+      "TMATE_SERVER_RSA_FINGERPRINT": /./,
+      "TMATE_SERVER_ED25519_FINGERPRINT": /./,
     }
 
     let host = "";
@@ -17564,10 +17564,10 @@ async function run() {
       const value = getValidatedEnvVars(key, option);
       if (value !== undefined) {
         setDefaultCommand = `${setDefaultCommand} set-option -g ${key} "${value}" \\;`;
-        if (key === "tmate-server-host") {
+        if (key === "TMATE_SERVER_HOST") {
           host = value;
         }
-        if (key === "tmate-server-port") {
+        if (key === "TMATE_SERVER_PORT") {
           port = value;
         }
       }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,7 +63,7 @@ export const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 export const getValidatedEnvVars = (key, re) => {
-  const value = process.env[key.toUpperCase()] || ""
+  const value = process.env[key] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -161,10 +161,10 @@ export async function run() {
     // values that are not, strictly speaking, valid, but should be good
     // enough for detecting obvious errors, which is all we want here.
     const options = {
-      "tmate-server-host": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
-      "tmate-server-port": /^\d{1,5}$/,
-      "tmate-server-rsa-fingerprint": /./,
-      "tmate-server-ed25519-fingerprint": /./,
+      "TMATE_SERVER_HOST": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
+      "TMATE_SERVER_PORT": /^\d{1,5}$/,
+      "TMATE_SERVER_RSA_FINGERPRINT": /./,
+      "TMATE_SERVER_ED25519_FINGERPRINT": /./,
     }
 
     let host = "";
@@ -173,10 +173,10 @@ export async function run() {
       const value = getValidatedEnvVars(key, option);
       if (value !== undefined) {
         setDefaultCommand = `${setDefaultCommand} set-option -g ${key} "${value}" \\;`;
-        if (key === "tmate-server-host") {
+        if (key === "TMATE_SERVER_HOST") {
           host = value;
         }
-        if (key === "tmate-server-port") {
+        if (key === "TMATE_SERVER_PORT") {
           port = value;
         }
       }


### PR DESCRIPTION
With reference to the comment on [GitHub Runner](https://github.com/canonical/github-runner-operator/pull/176#discussion_r1451970353) which the environment variable is used with Pythonic `_` underscores rather than `-`, this changes makes the action compatible.