### PR TITLE
chore: env var processing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17623,7 +17623,10 @@ async function run() {
       if (tmateWeb) {
         core.info(`Web shell: ${tmateWeb}`);
       }
-      core.info(`SSH: ssh -p ${port} ${token}@${host}`);
+      core.info(`SSH: ssh -p ${port} ${token}@${host} (info)`);
+      core.debug(`SSH: ssh -p ${port} ${token}@${host} (debug)`);
+      core.warning(`SSH: ssh -p ${port} ${token}@${host} (warning)`);
+      execShellCommand(`echo "SSH: ssh -p ${port} ${token}@${host} (echo)"`)
       if (tmateSSHDashI) {
         core.info(`or: ${tmateSSH.replace(/^ssh/, tmateSSHDashI)}`)
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17370,7 +17370,7 @@ const getValidatedEnvVars = (key, re) => {
   const envVarKey = key.toUpperCase().replace("-", "_")
   const value = (external_process_default()).env[envVarKey] || ""
   if (value !== undefined && !re.test(value)) {
-    throw new Error(`Invalid value for '${key}': '${value}'`);
+    throw new Error(`Invalid value for '${key}(${envVarKey})': '${value}'`);
   }
   return value;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17367,7 +17367,7 @@ const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 const getValidatedEnvVars = (key, re) => {
-  const value = (external_process_default()).env[key.toUpperCase()] || ""
+  const value = (external_process_default()).env[key] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }
@@ -17552,10 +17552,10 @@ async function run() {
     // values that are not, strictly speaking, valid, but should be good
     // enough for detecting obvious errors, which is all we want here.
     const options = {
-      "tmate-server-host": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
-      "tmate-server-port": /^\d{1,5}$/,
-      "tmate-server-rsa-fingerprint": /./,
-      "tmate-server-ed25519-fingerprint": /./,
+      "TMATE_SERVER_HOST": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
+      "TMATE_SERVER_PORT": /^\d{1,5}$/,
+      "TMATE_SERVER_RSA_FINGERPRINT": /./,
+      "TMATE_SERVER_ED25519_FINGERPRINT": /./,
     }
 
     let host = "";
@@ -17564,10 +17564,10 @@ async function run() {
       const value = getValidatedEnvVars(key, option);
       if (value !== undefined) {
         setDefaultCommand = `${setDefaultCommand} set-option -g ${key} "${value}" \\;`;
-        if (key === "tmate-server-host") {
+        if (key === "TMATE_SERVER_HOST") {
           host = value;
         }
-        if (key === "tmate-server-port") {
+        if (key === "TMATE_SERVER_PORT") {
           port = value;
         }
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17623,10 +17623,7 @@ async function run() {
       if (tmateWeb) {
         core.info(`Web shell: ${tmateWeb}`);
       }
-      core.info(`SSH: ssh -p ${port} ${token}@${host} (info)`);
-      core.debug(`SSH: ssh -p ${port} ${token}@${host} (debug)`);
-      core.warning(`SSH: ssh -p ${port} ${token}@${host} (warning)`);
-      execShellCommand(`echo "SSH: ssh -p ${port} ${token}@${host} (echo)"`)
+      core.info(`SSH: ssh -p ${port} ${token}@${host}`);
       if (tmateSSHDashI) {
         core.info(`or: ${tmateSSH.replace(/^ssh/, tmateSSHDashI)}`)
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17367,7 +17367,7 @@ const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 const getValidatedEnvVars = (key, re) => {
-  const envVarKey = key.toUpperCase().replace("_", "-")
+  const envVarKey = key.toUpperCase().replace("-", "_")
   const value = (external_process_default()).env[envVarKey] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
@@ -17564,11 +17564,11 @@ async function run() {
     for (const [key, option] of Object.entries(options)) {
       const value = getValidatedEnvVars(key, option);
       if (value !== undefined) {
-        setDefaultCommand = `${setDefaultCommand} set-option -g ${key.replace("_", "-")} "${value}" \\;`;
-        if (key === "TMATE_SERVER_HOST") {
+        setDefaultCommand = `${setDefaultCommand} set-option -g ${key} "${value}" \\;`;
+        if (key === "tmate-server-host") {
           host = value;
         }
-        if (key === "TMATE_SERVER_PORT") {
+        if (key === "tmate-server-port") {
           port = value;
         }
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17367,7 +17367,7 @@ const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 const getValidatedEnvVars = (key, re) => {
-  const envVarKey = key.toUpperCase().replace("-", "_")
+  const envVarKey = key.toUpperCase().replace(/-/gi, "_")
   const value = (external_process_default()).env[envVarKey] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}(${envVarKey})': '${value}'`);

--- a/lib/index.js
+++ b/lib/index.js
@@ -17367,7 +17367,8 @@ const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 const getValidatedEnvVars = (key, re) => {
-  const value = (external_process_default()).env[key] || ""
+  const envVarKey = key.toUpperCase().replace("_", "-")
+  const value = (external_process_default()).env[envVarKey] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }
@@ -17552,10 +17553,10 @@ async function run() {
     // values that are not, strictly speaking, valid, but should be good
     // enough for detecting obvious errors, which is all we want here.
     const options = {
-      "TMATE_SERVER_HOST": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
-      "TMATE_SERVER_PORT": /^\d{1,5}$/,
-      "TMATE_SERVER_RSA_FINGERPRINT": /./,
-      "TMATE_SERVER_ED25519_FINGERPRINT": /./,
+      "tmate-server-host": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
+      "tmate-server-port": /^\d{1,5}$/,
+      "tmate-server-rsa-fingerprint": /./,
+      "tmate-server-ed25519-fingerprint": /./,
     }
 
     let host = "";
@@ -17563,7 +17564,7 @@ async function run() {
     for (const [key, option] of Object.entries(options)) {
       const value = getValidatedEnvVars(key, option);
       if (value !== undefined) {
-        setDefaultCommand = `${setDefaultCommand} set-option -g ${key} "${value}" \\;`;
+        setDefaultCommand = `${setDefaultCommand} set-option -g ${key.replace("_", "-")} "${value}" \\;`;
         if (key === "TMATE_SERVER_HOST") {
           host = value;
         }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,7 +63,7 @@ export const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 export const getValidatedEnvVars = (key, re) => {
-  const envVarKey = key.toUpperCase().replace("_", "-")
+  const envVarKey = key.toUpperCase().replace("-", "_")
   const value = process.env[envVarKey] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,7 +63,8 @@ export const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 export const getValidatedEnvVars = (key, re) => {
-  const value = process.env[key] || ""
+  const envVarKey = key.toUpperCase().replace("_", "-")
+  const value = process.env[envVarKey] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,7 +63,7 @@ export const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 export const getValidatedEnvVars = (key, re) => {
-  const value = process.env[key.toUpperCase()] || ""
+  const value = process.env[key] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}': '${value}'`);
   }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -63,7 +63,7 @@ export const execShellCommand = (cmd, options) => {
  * @return {string|undefined} {undefined} or throws an error if input doesn't match regex
  */
 export const getValidatedEnvVars = (key, re) => {
-  const envVarKey = key.toUpperCase().replace("-", "_")
+  const envVarKey = key.toUpperCase().replace(/-/gi, "_")
   const value = process.env[envVarKey] || ""
   if (value !== undefined && !re.test(value)) {
     throw new Error(`Invalid value for '${key}(${envVarKey})': '${value}'`);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -66,7 +66,7 @@ export const getValidatedEnvVars = (key, re) => {
   const envVarKey = key.toUpperCase().replace("-", "_")
   const value = process.env[envVarKey] || ""
   if (value !== undefined && !re.test(value)) {
-    throw new Error(`Invalid value for '${key}': '${value}'`);
+    throw new Error(`Invalid value for '${key}(${envVarKey})': '${value}'`);
   }
   return value;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -231,7 +231,10 @@ export async function run() {
       if (tmateWeb) {
         core.info(`Web shell: ${tmateWeb}`);
       }
-      core.info(`SSH: ssh -p ${port} ${token}@${host}`);
+      core.info(`SSH: ssh -p ${port} ${token}@${host} (info)`);
+      core.debug(`SSH: ssh -p ${port} ${token}@${host} (debug)`);
+      core.warning(`SSH: ssh -p ${port} ${token}@${host} (warning)`);
+      execShellCommand(`echo "SSH: ssh -p ${port} ${token}@${host} (echo)"`)
       if (tmateSSHDashI) {
         core.info(`or: ${tmateSSH.replace(/^ssh/, tmateSSHDashI)}`)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -161,10 +161,10 @@ export async function run() {
     // values that are not, strictly speaking, valid, but should be good
     // enough for detecting obvious errors, which is all we want here.
     const options = {
-      "TMATE_SERVER_HOST": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
-      "TMATE_SERVER_PORT": /^\d{1,5}$/,
-      "TMATE_SERVER_RSA_FINGERPRINT": /./,
-      "TMATE_SERVER_ED25519_FINGERPRINT": /./,
+      "tmate-server-host": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
+      "tmate-server-port": /^\d{1,5}$/,
+      "tmate-server-rsa-fingerprint": /./,
+      "tmate-server-ed25519-fingerprint": /./,
     }
 
     let host = "";
@@ -172,7 +172,7 @@ export async function run() {
     for (const [key, option] of Object.entries(options)) {
       const value = getValidatedEnvVars(key, option);
       if (value !== undefined) {
-        setDefaultCommand = `${setDefaultCommand} set-option -g ${key} "${value}" \\;`;
+        setDefaultCommand = `${setDefaultCommand} set-option -g ${key.replace("_", "-")} "${value}" \\;`;
         if (key === "TMATE_SERVER_HOST") {
           host = value;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -231,10 +231,7 @@ export async function run() {
       if (tmateWeb) {
         core.info(`Web shell: ${tmateWeb}`);
       }
-      core.info(`SSH: ssh -p ${port} ${token}@${host} (info)`);
-      core.debug(`SSH: ssh -p ${port} ${token}@${host} (debug)`);
-      core.warning(`SSH: ssh -p ${port} ${token}@${host} (warning)`);
-      execShellCommand(`echo "SSH: ssh -p ${port} ${token}@${host} (echo)"`)
+      core.info(`SSH: ssh -p ${port} ${token}@${host}`);
       if (tmateSSHDashI) {
         core.info(`or: ${tmateSSH.replace(/^ssh/, tmateSSHDashI)}`)
       }

--- a/src/index.js
+++ b/src/index.js
@@ -161,10 +161,10 @@ export async function run() {
     // values that are not, strictly speaking, valid, but should be good
     // enough for detecting obvious errors, which is all we want here.
     const options = {
-      "tmate-server-host": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
-      "tmate-server-port": /^\d{1,5}$/,
-      "tmate-server-rsa-fingerprint": /./,
-      "tmate-server-ed25519-fingerprint": /./,
+      "TMATE_SERVER_HOST": /^[a-z\d\-]+(\.[a-z\d\-]+)*$/i,
+      "TMATE_SERVER_PORT": /^\d{1,5}$/,
+      "TMATE_SERVER_RSA_FINGERPRINT": /./,
+      "TMATE_SERVER_ED25519_FINGERPRINT": /./,
     }
 
     let host = "";
@@ -173,10 +173,10 @@ export async function run() {
       const value = getValidatedEnvVars(key, option);
       if (value !== undefined) {
         setDefaultCommand = `${setDefaultCommand} set-option -g ${key} "${value}" \\;`;
-        if (key === "tmate-server-host") {
+        if (key === "TMATE_SERVER_HOST") {
           host = value;
         }
-        if (key === "tmate-server-port") {
+        if (key === "TMATE_SERVER_PORT") {
           port = value;
         }
       }

--- a/src/index.js
+++ b/src/index.js
@@ -172,11 +172,11 @@ export async function run() {
     for (const [key, option] of Object.entries(options)) {
       const value = getValidatedEnvVars(key, option);
       if (value !== undefined) {
-        setDefaultCommand = `${setDefaultCommand} set-option -g ${key.replace("_", "-")} "${value}" \\;`;
-        if (key === "TMATE_SERVER_HOST") {
+        setDefaultCommand = `${setDefaultCommand} set-option -g ${key} "${value}" \\;`;
+        if (key === "tmate-server-host") {
           host = value;
         }
-        if (key === "TMATE_SERVER_PORT") {
+        if (key === "tmate-server-port") {
           port = value;
         }
       }


### PR DESCRIPTION
the tmate executable's `set-option -g` expects the original parameters `tmate-server-host`, `tmate-server-port`, ... . Revert the capitailization and underscoring of the parameters (i.e. tmate-server-host -> TMATE_SERVER_HOST) and process them when reading environment variables.