### PR TITLE
docs: fix ref to branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup tmate session
-      uses: canonical/action-tmate@master
+      uses: canonical/action-tmate@main
 ```
 
 To get the connection string, just open the `Checks` tab in your Pull Request and scroll to the bottom. There you can connect either directly per SSH or via a web based terminal.


### PR DESCRIPTION
Applicable spec: N/A

### Overview

The repository's default branch is `main` not `master`.

### Rationale

Documentation fix.

### Module Changes

None.

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation on README.md is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
