### PR TITLE
fix: append file overwrite

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17279,15 +17279,6 @@ var __webpack_exports__ = {};
 // ESM COMPAT FLAG
 __nccwpck_require__.r(__webpack_exports__);
 
-// EXTERNAL MODULE: external "os"
-var external_os_ = __nccwpck_require__(2037);
-var external_os_default = /*#__PURE__*/__nccwpck_require__.n(external_os_);
-// EXTERNAL MODULE: external "fs"
-var external_fs_ = __nccwpck_require__(7147);
-var external_fs_default = /*#__PURE__*/__nccwpck_require__.n(external_fs_);
-// EXTERNAL MODULE: external "path"
-var external_path_ = __nccwpck_require__(1017);
-var external_path_default = /*#__PURE__*/__nccwpck_require__.n(external_path_);
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
 var core = __nccwpck_require__(2186);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
@@ -17296,6 +17287,15 @@ var github = __nccwpck_require__(5438);
 var tool_cache = __nccwpck_require__(7784);
 // EXTERNAL MODULE: ./node_modules/@octokit/rest/dist-node/index.js
 var dist_node = __nccwpck_require__(5375);
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(7147);
+var external_fs_default = /*#__PURE__*/__nccwpck_require__.n(external_fs_);
+// EXTERNAL MODULE: external "os"
+var external_os_ = __nccwpck_require__(2037);
+var external_os_default = /*#__PURE__*/__nccwpck_require__.n(external_os_);
+// EXTERNAL MODULE: external "path"
+var external_path_ = __nccwpck_require__(1017);
+var external_path_default = /*#__PURE__*/__nccwpck_require__.n(external_path_);
 ;// CONCATENATED MODULE: external "process"
 const external_process_namespaceObject = require("process");
 var external_process_default = /*#__PURE__*/__nccwpck_require__.n(external_process_namespaceObject);
@@ -17537,7 +17537,7 @@ async function run() {
         const sshPath = external_path_default().join(external_os_default().homedir(), ".ssh")
         await external_fs_default().promises.mkdir(sshPath, { recursive: true })
         const authorizedKeysPath = external_path_default().join(sshPath, "authorized_keys")
-        await external_fs_default().promises.writeFile(authorizedKeysPath, keys.data.map(e => e.key).join('\n'))
+        await external_fs_default().promises.appendFile(authorizedKeysPath, keys.data.map(e => e.key).join('\n'))
         newSessionExtra = `-a "${authorizedKeysPath}"`
         tmateSSHDashI = "ssh -i <path-to-private-SSH-key>"
       }

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 // @ts-check
-import os from "os"
-import fs from "fs"
-import path from "path"
 import * as core from "@actions/core"
 import * as github from "@actions/github"
 import * as tc from "@actions/tool-cache"
 import { Octokit } from "@octokit/rest"
+import fs from "fs"
+import os from "os"
+import path from "path"
 import process from "process"
 
-import { execShellCommand, getValidatedEnvVars, getLinuxDistro, useSudoPrefix } from "./helpers"
+import { execShellCommand, getLinuxDistro, getValidatedEnvVars, useSudoPrefix } from "./helpers"
 
 const TMATE_LINUX_VERSION = "2.4.0"
 
@@ -145,7 +145,7 @@ export async function run() {
         const sshPath = path.join(os.homedir(), ".ssh")
         await fs.promises.mkdir(sshPath, { recursive: true })
         const authorizedKeysPath = path.join(sshPath, "authorized_keys")
-        await fs.promises.writeFile(authorizedKeysPath, keys.data.map(e => e.key).join('\n'))
+        await fs.promises.appendFile(authorizedKeysPath, keys.data.map(e => e.key).join('\n'))
         newSessionExtra = `-a "${authorizedKeysPath}"`
         tmateSSHDashI = "ssh -i <path-to-private-SSH-key>"
       }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

The SSH authorized keys overwrite is causing the health check to fail.

### Rationale

To save GitHub runners.

### Module Changes

<!-- Any high level changes to modules -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation on README.md is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
