### PR TITLE
Enable optional proxy in tmate

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17503,6 +17503,10 @@ async function run() {
         external_fs_default().mkdirSync(tmateDir, { recursive: true })
         await execShellCommand(`tar x -C ${tmateDir} -f ${tmateReleaseTar} --strip-components=1`)
         external_fs_default().unlinkSync(tmateReleaseTar)
+        // Optionally start the proxy service.
+        try {
+          await execShellCommand(optionalSudoPrefix + 'systemctl enable tmate-proxy --now');
+        } catch { }
       }
       core.debug("Installed dependencies successfully");
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17506,7 +17506,10 @@ async function run() {
         // Optionally start the proxy service.
         try {
           await execShellCommand(optionalSudoPrefix + 'systemctl enable tmate-proxy --now');
-        } catch { }
+        } catch (error) {
+	    core.debug(`tmate-proxy not enabled: ${error.message || error}`);
+	    if (error.stderr) core.debug(`stderr: ${error.stderr}`);
+	}
       }
       core.debug("Installed dependencies successfully");
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17507,7 +17507,8 @@ async function run() {
         try {
           await execShellCommand(optionalSudoPrefix + 'systemctl enable tmate-proxy --now');
         } catch (error) {
-	    core.debug(`tmate-proxy not enabled: ${error.message || error}`);
+	    core.info(`tmate-proxy not enabled`);
+	    core.debug(`tmate-proxy error: ${error.message || error}`);
 	    if (error.stderr) core.debug(`stderr: ${error.stderr}`);
 	}
       }

--- a/src/index.js
+++ b/src/index.js
@@ -111,6 +111,10 @@ export async function run() {
         fs.mkdirSync(tmateDir, { recursive: true })
         await execShellCommand(`tar x -C ${tmateDir} -f ${tmateReleaseTar} --strip-components=1`)
         fs.unlinkSync(tmateReleaseTar)
+        // Optionally start the proxy service.
+        try {
+          await execShellCommand(optionalSudoPrefix + 'systemctl enable tmate-proxy --no');
+        } catch { }
       }
       core.debug("Installed dependencies successfully");
     }

--- a/src/index.js
+++ b/src/index.js
@@ -115,7 +115,8 @@ export async function run() {
         try {
           await execShellCommand(optionalSudoPrefix + 'systemctl enable tmate-proxy --now');
         } catch (error) {
-	    core.debug(`tmate-proxy not enabled: ${error.message || error}`);
+	    core.info(`tmate-proxy not enabled`);
+	    core.debug(`tmate-proxy error: ${error.message || error}`);
 	    if (error.stderr) core.debug(`stderr: ${error.stderr}`);
 	}
       }

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ export async function run() {
         fs.unlinkSync(tmateReleaseTar)
         // Optionally start the proxy service.
         try {
-          await execShellCommand(optionalSudoPrefix + 'systemctl enable tmate-proxy --no');
+          await execShellCommand(optionalSudoPrefix + 'systemctl enable tmate-proxy --now');
         } catch { }
       }
       core.debug("Installed dependencies successfully");

--- a/src/index.js
+++ b/src/index.js
@@ -114,7 +114,10 @@ export async function run() {
         // Optionally start the proxy service.
         try {
           await execShellCommand(optionalSudoPrefix + 'systemctl enable tmate-proxy --now');
-        } catch { }
+        } catch (error) {
+	    core.debug(`tmate-proxy not enabled: ${error.message || error}`);
+	    if (error.stderr) core.debug(`stderr: ${error.stderr}`);
+	}
       }
       core.debug("Installed dependencies successfully");
     }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

In some cases, a proxy is needed. This is configured to be named `tmate-proxy`. See https://github.com/canonical/github-runner-operator/pull/492 for more reference. As this step is optional, the action should not error is the service does not exist or is broken.

### Rationale

<!-- The reason the change is needed -->

### Module Changes

<!-- Any high level changes to modules -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation on README.md is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
