### PR TITLE
use DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13647,9 +13647,9 @@ async function run() {
     if (core.getInput("install-dependencies") !== "false") {
       core.debug("Installing dependencies")
       const optionalSudoPrefix = useSudoPrefix() ? "sudo " : "";
-      await execShellCommand(optionalSudoPrefix + 'apt-get update');
-      await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
-      await execShellCommand(optionalSudoPrefix + 'apt-get install -y tmate');
+      await execShellCommand(optionalSudoPrefix + 'DEBIAN_FRONTEND=noninteractive apt-get update');
+      await execShellCommand(optionalSudoPrefix + 'DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-client xz-utils');
+      await execShellCommand(optionalSudoPrefix + 'DEBIAN_FRONTEND=noninteractive apt-get install -y tmate');
 
       const tmateArch = TMATE_ARCH_MAP[external_os_default().arch()];
       if (!tmateArch) {

--- a/src/index.js
+++ b/src/index.js
@@ -86,9 +86,9 @@ export async function run() {
     if (core.getInput("install-dependencies") !== "false") {
       core.debug("Installing dependencies")
       const optionalSudoPrefix = useSudoPrefix() ? "sudo " : "";
-      await execShellCommand(optionalSudoPrefix + 'apt-get update');
-      await execShellCommand(optionalSudoPrefix + 'apt-get install -y openssh-client xz-utils');
-      await execShellCommand(optionalSudoPrefix + 'apt-get install -y tmate');
+      await execShellCommand(optionalSudoPrefix + 'DEBIAN_FRONTEND=noninteractive apt-get update');
+      await execShellCommand(optionalSudoPrefix + 'DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-client xz-utils');
+      await execShellCommand(optionalSudoPrefix + 'DEBIAN_FRONTEND=noninteractive apt-get install -y tmate');
 
       const tmateArch = TMATE_ARCH_MAP[os.arch()];
       if (!tmateArch) {


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Use non-interactive mode for apt operations

### Rationale

for fips runners, tmate installation was blocked due to hanging whiptail waiting for user input. Generally, in CI we should use DEBIAN_FRONTEND=noninteractive to avoid blocking CI.

### Module Changes

<!-- Any high level changes to modules -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The documentation on README.md is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

No reason to update README.md

<!-- Explanation for any unchecked items above -->
