### PR TITLE
Add input for tmate connectivity verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,24 @@ jobs:
         # Send a Slack message to someone telling them they can ssh to ${{ needs.setup-tmate.outputs.ssh-address }}
 ```
 
+## Connectivity check
+
+You can verify that the runner can reach the tmate server without starting an interactive session. When `connectivity-check` is set to `true`, the action creates a tmate session, logs the connection details, and immediately terminates.
+
+```yaml
+name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+    - uses: actions/checkout@v4
+    - name: Verify tmate connectivity
+      uses: canonical/action-tmate@main
+      with:
+        connectivity-check: true
+```
+
 ## Without sudo
 
 By default we run installation commands using sudo on Linux. If you get `sudo: not found` you can use the parameter below to execute the commands directly.

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: 'The root of the MSYS2 installation (on Windows runners)'
     required: false
     default: 'C:\msys64'
+  smoke-test:
+    description: 'If true, connect to the tmate server and exit immediately (connectivity test)'
+    required: false
+    default: 'false'
   github-token:
     description: >
       Personal access token (PAT) used to call into GitHub's REST API.

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
     description: 'The root of the MSYS2 installation (on Windows runners)'
     required: false
     default: 'C:\msys64'
-  smoke-test:
+  connectivity-check:
     description: 'If true, connect to the tmate server and exit immediately (connectivity test)'
     required: false
     default: 'false'

--- a/detached/action.yml
+++ b/detached/action.yml
@@ -49,6 +49,10 @@ inputs:
     description: 'The root of the MSYS2 installation (on Windows runners)'
     required: false
     default: 'C:\msys64'
+  smoke-test:
+    description: 'If true, connect to the tmate server and exit immediately (connectivity test)'
+    required: false
+    default: 'false'
   github-token:
     description: >
       Personal access token (PAT) used to call into GitHub's REST API.

--- a/detached/action.yml
+++ b/detached/action.yml
@@ -49,7 +49,7 @@ inputs:
     description: 'The root of the MSYS2 installation (on Windows runners)'
     required: false
     default: 'C:\msys64'
-  smoke-test:
+  connectivity-check:
     description: 'If true, connect to the tmate server and exit immediately (connectivity test)'
     required: false
     default: 'false'

--- a/lib/index.js
+++ b/lib/index.js
@@ -13781,14 +13781,14 @@ async function run() {
     const [token,] = tokenHost.split("@")
     const tmateWeb = await execShellCommand(`${tmate} display -p '#{tmate_web}'`);
 
-    if (core.getInput("smoke-test") === "true") {
-      core.info("Smoke test: tmate session created successfully")
+    if (core.getInput("connectivity-check") === "true") {
+      core.info("Connectivity check: tmate session created successfully")
       core.info(`SSH: ${tmateSSH}`)
       if (tmateWeb) {
         core.info(`Web shell: ${tmateWeb}`)
       }
       await execShellCommand(`${tmate} kill-session`)
-      core.info("Smoke test: session terminated, connectivity verified")
+      core.info("Connectivity check: session terminated, connectivity verified")
       return
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13781,6 +13781,17 @@ async function run() {
     const [token,] = tokenHost.split("@")
     const tmateWeb = await execShellCommand(`${tmate} display -p '#{tmate_web}'`);
 
+    if (core.getInput("smoke-test") === "true") {
+      core.info("Smoke test: tmate session created successfully")
+      core.info(`SSH: ${tmateSSH}`)
+      if (tmateWeb) {
+        core.info(`Web shell: ${tmateWeb}`)
+      }
+      await execShellCommand(`${tmate} kill-session`)
+      core.info("Smoke test: session terminated, connectivity verified")
+      return
+    }
+
     /*
       * Publish a variable so that when the POST action runs, it can determine
       * it should run the appropriate logic. This is necessary since we don't

--- a/src/index.js
+++ b/src/index.js
@@ -191,14 +191,14 @@ export async function run() {
     const [token,] = tokenHost.split("@")
     const tmateWeb = await execShellCommand(`${tmate} display -p '#{tmate_web}'`);
 
-    if (core.getInput("smoke-test") === "true") {
-      core.info("Smoke test: tmate session created successfully")
+    if (core.getInput("connectivity-check") === "true") {
+      core.info("Connectivity check: tmate session created successfully")
       core.info(`SSH: ${tmateSSH}`)
       if (tmateWeb) {
         core.info(`Web shell: ${tmateWeb}`)
       }
       await execShellCommand(`${tmate} kill-session`)
-      core.info("Smoke test: session terminated, connectivity verified")
+      core.info("Connectivity check: session terminated, connectivity verified")
       return
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -191,6 +191,17 @@ export async function run() {
     const [token,] = tokenHost.split("@")
     const tmateWeb = await execShellCommand(`${tmate} display -p '#{tmate_web}'`);
 
+    if (core.getInput("smoke-test") === "true") {
+      core.info("Smoke test: tmate session created successfully")
+      core.info(`SSH: ${tmateSSH}`)
+      if (tmateWeb) {
+        core.info(`Web shell: ${tmateWeb}`)
+      }
+      await execShellCommand(`${tmate} kill-session`)
+      core.info("Smoke test: session terminated, connectivity verified")
+      return
+    }
+
     /*
       * Publish a variable so that when the POST action runs, it can determine
       * it should run the appropriate logic. This is necessary since we don't

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -22,9 +22,11 @@ jest.mock('./helpers', () => {
     __esModule: true,
     ...originalModule,
     execShellCommand: jest.fn(() => 'mocked execShellCommand'),
+    getValidatedEnvVars: jest.fn(originalModule.getValidatedEnvVars),
+    updateSshConfig: jest.fn(originalModule.updateSshConfig),
   };
 });
-import { execShellCommand } from "./helpers"
+import { execShellCommand, getValidatedEnvVars, updateSshConfig } from "./helpers"
 import { run } from "."
 
 describe('Tmate GitHub integration', () => {
@@ -117,6 +119,37 @@ describe('Tmate GitHub integration', () => {
     core.getInput.mockReturnValueOnce("false")
     await run()
     expect(execShellCommand).not.toHaveBeenNthCalledWith(1, "brew install tmate")
+  });
+  it('should create session and exit immediately in smoke-test mode', async () => {
+    Object.defineProperty(process, "platform", {
+      value: "linux"
+    })
+    const customConnectionString = "ssh -p2222 foobar@test.example.com"
+    const webUrl = "https://test.example.com"
+    execShellCommand.mockImplementation((cmd) => {
+      if (cmd.includes("tmate_web")) return Promise.resolve(webUrl)
+      if (cmd.includes("tmate_ssh")) return Promise.resolve(customConnectionString)
+      return Promise.resolve("")
+    })
+    core.getInput.mockImplementation((name) => {
+      if (name === "install-dependencies") return "false"
+      if (name === "limit-access-to-actor") return "false"
+      if (name === "smoke-test") return "true"
+      return ""
+    })
+    getValidatedEnvVars.mockReturnValue(undefined)
+    updateSshConfig.mockResolvedValue(undefined)
+
+    await run()
+
+    expect(core.info).toHaveBeenCalledWith("Smoke test: tmate session created successfully")
+    expect(core.info).toHaveBeenCalledWith(`SSH: ${customConnectionString}`)
+    expect(core.info).toHaveBeenCalledWith(`Web shell: ${webUrl}`)
+    expect(execShellCommand).toHaveBeenCalledWith(
+      expect.stringContaining("kill-session")
+    )
+    expect(core.info).toHaveBeenCalledWith("Smoke test: session terminated, connectivity verified")
+    expect(core.saveState).not.toHaveBeenCalledWith('isPost', 'true')
   });
   it('should work without any options', async () => {
     core.getInput.mockReturnValue("");

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -120,7 +120,7 @@ describe('Tmate GitHub integration', () => {
     await run()
     expect(execShellCommand).not.toHaveBeenNthCalledWith(1, "brew install tmate")
   });
-  it('should create session and exit immediately in smoke-test mode', async () => {
+  it('should create session and exit immediately in connectivity-check mode', async () => {
     Object.defineProperty(process, "platform", {
       value: "linux"
     })
@@ -134,7 +134,7 @@ describe('Tmate GitHub integration', () => {
     core.getInput.mockImplementation((name) => {
       if (name === "install-dependencies") return "false"
       if (name === "limit-access-to-actor") return "false"
-      if (name === "smoke-test") return "true"
+      if (name === "connectivity-check") return "true"
       return ""
     })
     getValidatedEnvVars.mockReturnValue(undefined)
@@ -142,13 +142,13 @@ describe('Tmate GitHub integration', () => {
 
     await run()
 
-    expect(core.info).toHaveBeenCalledWith("Smoke test: tmate session created successfully")
+    expect(core.info).toHaveBeenCalledWith("Connectivity check: tmate session created successfully")
     expect(core.info).toHaveBeenCalledWith(`SSH: ${customConnectionString}`)
     expect(core.info).toHaveBeenCalledWith(`Web shell: ${webUrl}`)
     expect(execShellCommand).toHaveBeenCalledWith(
       expect.stringContaining("kill-session")
     )
-    expect(core.info).toHaveBeenCalledWith("Smoke test: session terminated, connectivity verified")
+    expect(core.info).toHaveBeenCalledWith("Connectivity check: session terminated, connectivity verified")
     expect(core.saveState).not.toHaveBeenCalledWith('isPost', 'true')
   });
   it('should work without any options', async () => {


### PR DESCRIPTION
### Overview

Creates a tmate session, verifies connectivity by logging SSH/web connection strings, kills the session, and exits without entering the post phase.

Tested in https://github.com/canonical/cbartz-runner-testing/actions/runs/21626580760/job/62328632953
### Rationale

This is useful to check whether a self-hosted runner deployment is healthy and tmate action is able to connect to the tmate server.

### Module Changes

<!-- Any high level changes to modules -->

### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation on README.md is updated.

<!-- Explanation for any unchecked items above -->
