### PR TITLE
fix: prevent redundant post step run during connectivity check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13621,7 +13621,15 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 async function run() {
   try {
     /*  Indicates whether the POST action is running */
-    if (!!core.getState('isPost')) {
+    const isPost = !!core.getState('isPost')
+    // Since main and post share the same entry point (lib/index.js), we use
+    // saveState/getState to distinguish them. This call has no effect on the
+    // current run — it tells the GitHub Actions runner to pass 'isPost' to
+    // the post step so it can detect itself. Must happen before any early
+    // return (e.g. connectivity-check).
+    core.saveState('isPost', 'true')
+
+    if (isPost) {
       const message = core.getState('message')
       const tmate = core.getState('tmate')
       if (tmate && message) {
@@ -13791,15 +13799,6 @@ async function run() {
       core.info("Connectivity check: session terminated, connectivity verified")
       return
     }
-
-    /*
-      * Publish a variable so that when the POST action runs, it can determine
-      * it should run the appropriate logic. This is necessary since we don't
-      * have a separate entry point.
-      *
-      * Inspired by https://github.com/actions/checkout/blob/v3.1.0/src/state-helper.ts#L56-L60
-      */
-    core.saveState('isPost', 'true')
 
     const detached = core.getInput("detached")
     if (detached === "true") {

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,15 @@ const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 export async function run() {
   try {
     /*  Indicates whether the POST action is running */
-    if (!!core.getState('isPost')) {
+    const isPost = !!core.getState('isPost')
+    // Since main and post share the same entry point (lib/index.js), we use
+    // saveState/getState to distinguish them. This call has no effect on the
+    // current run — it tells the GitHub Actions runner to pass 'isPost' to
+    // the post step so it can detect itself. Must happen before any early
+    // return (e.g. connectivity-check).
+    core.saveState('isPost', 'true')
+
+    if (isPost) {
       const message = core.getState('message')
       const tmate = core.getState('tmate')
       if (tmate && message) {
@@ -201,15 +209,6 @@ export async function run() {
       core.info("Connectivity check: session terminated, connectivity verified")
       return
     }
-
-    /*
-      * Publish a variable so that when the POST action runs, it can determine
-      * it should run the appropriate logic. This is necessary since we don't
-      * have a separate entry point.
-      *
-      * Inspired by https://github.com/actions/checkout/blob/v3.1.0/src/state-helper.ts#L56-L60
-      */
-    core.saveState('isPost', 'true')
 
     const detached = core.getInput("detached")
     if (detached === "true") {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -149,7 +149,7 @@ describe('Tmate GitHub integration', () => {
       expect.stringContaining("kill-session")
     )
     expect(core.info).toHaveBeenCalledWith("Connectivity check: session terminated, connectivity verified")
-    expect(core.saveState).not.toHaveBeenCalledWith('isPost', 'true')
+    expect(core.saveState).toHaveBeenCalledWith('isPost', 'true')
   });
   it('should work without any options', async () => {
     core.getInput.mockReturnValue("");


### PR DESCRIPTION
### Overview

Move core.saveState('isPost', 'true') to the top of run() so the post step always detects itself and returns immediately.

Tested in https://github.com/canonical/platform-engineering-testing/actions/runs/22396554764/job/64831595114 

### Rationale

When connectivity-check is true, the main step returned before setting the isPost state. This caused the post step to re-run the entire main logic (apt-get install, tmate session creation, connectivity check) redundantly.



### Checklist

- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The documentation on README.md is updated.
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
